### PR TITLE
Bugfix/#26 remove gathering timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
 - oraclejdk8
 install: true

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -112,19 +112,6 @@ public class PeerIceModule {
         log.debug(getLogPrefix() + "Sending own candidates to {}", peer.getRemoteId());
         setState(AWAITING_CANDIDATES);
         RPCService.onIceMsg(localCandidatesMessage);
-
-        //TODO: is this a good fix for awaiting candidates loop????
-        //Make sure to abort the connection process and reinitiate when we haven't received an answer to our offer in 6 seconds, candidate packet was probably lost
-        final int currentacei = ++awaitingCandidatesEventId;
-        Executor.executeDelayed(6_000, () -> {
-            if(peer.isClosing()) {
-                log.warn(getLogPrefix() + "Peer {} not connected anymore, aborting reinitiation of ICE", peer.getRemoteId());
-                return;
-            }
-            if (iceState == AWAITING_CANDIDATES && currentacei == awaitingCandidatesEventId) {
-                onConnectionLost();
-            }
-        });
     }
 
     //How often have we been waiting for a response to local candidates/offer

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -182,7 +182,7 @@ public class PeerIceModule {
 
         //Wait for termination/completion of the agent
         long iceStartTime = System.currentTimeMillis();
-        while (agent.getState().isOver()) {
+        while (!agent.getState().isOver()) {
             try {
                 Thread.sleep(20);
             } catch (InterruptedException e) {


### PR DESCRIPTION
Removed gathering timeouts and replaced check for completeness of agent.getState() with agent.getState().isOver(). Following the connectivity establishment the result is logged and if the state is either FAILED or TERMINATED then the thread exits (as per before).

To clarify why both timeouts of the gathering process were removed: the first timeout was preventing the agent from finishing gathering candidates, which is guaranteed to finish. The second timeout was unnecessary and could cause connectivity establishment failure because
1. the transport protocol used is tcp i.e. guaranteed packet delivery
2. If the peer takes longer than 6 seconds to gather candidates, the connection is reinitiated resulting in the potential for a loop.