### PR TITLE
Estimate latency based on faf protocol

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,5 +34,5 @@ dependencies {
 }
 
 task createAllJars (type: GradleBuild) {
-    tasks = [":client:shadowJar",":server:shadowJar",":ice-adapter:shadowJar"]
+    tasks = [":client:shadowJar",":server:shadowJar",":ice-adapter:shadowJar",":echo-server:shadowJar"]
 }

--- a/echo-server/build.gradle
+++ b/echo-server/build.gradle
@@ -1,0 +1,40 @@
+buildscript {
+    dependencies {
+        classpath group: 'de.dynamicfiles.projects.gradle.plugins', name: 'javafx-gradle-plugin', version: '8.8.2'
+    }
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+apply plugin: 'idea'
+apply plugin: 'java'
+apply plugin: 'java-library'
+apply plugin: 'io.franzbecker.gradle-lombok'
+apply plugin: 'javafx-gradle-plugin'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+group 'Geosearchef'
+version = 'SNAPSHOT'
+
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+    maven { url "https://jitpack.io" }
+}
+
+dependencies {
+    implementation "org.slf4j:slf4j-api:1.7.25"
+    implementation "ch.qos.logback:logback-classic:1.2.3"
+    implementation "ch.qos.logback:logback-core:1.2.3"
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'com.faforever.echoserver.EchoServer'
+    }
+}

--- a/echo-server/src/main/java/com/faforever/echoserver/EchoServer.java
+++ b/echo-server/src/main/java/com/faforever/echoserver/EchoServer.java
@@ -1,0 +1,94 @@
+package com.faforever.echoserver;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class EchoServer {
+
+    public static final int ECHO_PORT = 14010; // TODO: env variable
+    public static final int CONNECTION_TIMEOUT = 5000;
+
+    private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    private static ServerSocket serverSocket;
+    private static volatile boolean running = true;
+
+
+    public static void main(String args[]) {
+        log.info("Starting echo server");
+
+        startServer();
+    }
+
+    private static void startServer() {
+        try {
+            serverSocket = new ServerSocket(ECHO_PORT, 100);
+        } catch (IOException e) {
+            log.error("Couldn't bind server socket to port {}", ECHO_PORT);
+            System.exit(1);
+        }
+
+        new Thread(EchoServer::serverSocketListener).start();
+    }
+
+    private static void serverSocketListener() {
+        while(running) {
+            try {
+                Socket client = serverSocket.accept();
+
+                Thread thread = new Thread(() -> clientListener(client));
+                thread.start();
+
+                executor.schedule(() -> {
+                    if(! client.isClosed()) {
+                        thread.stop();
+                        try {
+                            client.close();
+                        } catch(IOException e) {
+                            log.warn("Error while timing out client connection");
+                        }
+                    }
+                }, CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+
+            } catch(IOException e) {
+                log.warn("Error while accepting client connection", e);
+            }
+        }
+    }
+
+    private static void clientListener(Socket client) {
+        try {
+            DataInputStream in = new DataInputStream(client.getInputStream());
+            DataOutputStream out = new DataOutputStream(client.getOutputStream());
+
+            byte[] buffer = new byte[100];
+            int bytesRead = 0;
+            while(bytesRead < 100) {
+                bytesRead += in.read(buffer, bytesRead, 100 - bytesRead);
+            }
+
+            out.write(new byte[] {1, 2, 3, 4});
+
+            out.close(); // flushes
+            in.close();
+
+        } catch(IOException e) {
+            log.warn("Error while communicating with client {}", client.getInetAddress().getHostAddress());
+        } finally {
+            try {
+                client.close();
+            } catch (IOException e) {
+                log.warn("Error while closing client connection");
+            }
+        }
+    }
+}

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/IceAdapter.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/IceAdapter.java
@@ -36,6 +36,9 @@ public class IceAdapter {
     public static int PING_COUNT = 1;
     public static double ACCEPTABLE_LATENCY = 250.0;
 
+    public static int GPGNET_SERVER_BIND_RETRY_COUNT = 3;
+    public static int GPGNET_SERVER_BIND_RETRY_DELAY = 500;
+
     public static volatile GameSession gameSession;
 
     public static void main(String args[]) {

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/GameSession.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/GameSession.java
@@ -1,7 +1,7 @@
 package com.faforever.iceadapter.ice;
 
 import com.faforever.iceadapter.IceAdapter;
-import com.faforever.iceadapter.util.PingWrapper;
+import com.faforever.iceadapter.util.latencyestimation.LatencyEstimator;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -92,7 +92,7 @@ public class GameSession {
                 new CacheLoader<String, CompletableFuture<OptionalDouble>>() {
                     @Override
                     public CompletableFuture<OptionalDouble> load(String host) throws Exception {
-                        return PingWrapper.getLatency(host, IceAdapter.PING_COUNT)
+                        return LatencyEstimator.getLatency(host)
                                 .thenApply(OptionalDouble::of)
                                 .exceptionally(ex -> OptionalDouble.empty());
                     }

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -416,6 +416,9 @@ public class PeerIceModule {
                 if (packet.getLength() == 0) {
                     continue;
                 }
+                if (packet.getLength() > data.length - 1000) {
+                    log.warn("Received packet is very long at {} bytes, maybe an overflow occured!?", packet.getLength());
+                }
 
                 if (data[0] == 'd') {
                     //Received data

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -36,6 +36,8 @@ public class PeerIceModule {
     private static final int FORCE_SRFLX_COUNT = 1;
     private static final int FORCE_RELAY_COUNT = 2;
 
+    private static final int GATHERING_TIMEOUT = 5000;
+
     private Peer peer;
 
     private Agent agent;
@@ -116,7 +118,7 @@ public class PeerIceModule {
             }
         });
 
-        Executor.executeDelayed(5000, () -> {
+        Executor.executeDelayed(GATHERING_TIMEOUT, () -> {
             if(! gatheringFuture.isDone()) {
                 gatheringFuture.cancel(true);
             }
@@ -408,7 +410,7 @@ public class PeerIceModule {
         Component localComponent = component;
 
         byte data[] = new byte[65536];//64KiB = UDP MTU, in practice due to ethernet frames being <= 1500 B, this is often not used
-        while (IceAdapter.running && IceAdapter.gameSession == peer.getGameSession()) {
+        while (IceAdapter.running && IceAdapter.gameSession == peer.getGameSession()) { // TODO: && listenerThread == this thread
             try {
                 DatagramPacket packet = new DatagramPacket(data, data.length);
                 localComponent.getSelectedPair().getIceSocketWrapper().getUDPSocket().receive(packet);

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/CandidateUtil.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/CandidateUtil.java
@@ -2,17 +2,23 @@ package com.faforever.iceadapter.util;
 
 import com.faforever.iceadapter.ice.CandidatePacket;
 import com.faforever.iceadapter.ice.CandidatesMessage;
+import lombok.extern.slf4j.Slf4j;
 import org.ice4j.Transport;
 import org.ice4j.TransportAddress;
 import org.ice4j.ice.*;
 
 import java.util.Collections;
 
+@Slf4j
 public class CandidateUtil {
 
     public static int candidateIDFactory = 0;
 
     public static CandidatesMessage packCandidates(int srcId, int destId, Agent agent, Component component, boolean allowHost, boolean allowReflexive, boolean allowRelay) {
+        if(! allowHost || ! allowReflexive || !allowRelay) {
+            log.info("Peer {}: Disallowing own candidates, host: {}, reflexive: {}, relay: {}", destId, allowHost, allowReflexive, allowRelay);
+        }
+
         CandidatesMessage localCandidatesMessage = new CandidatesMessage(srcId, destId, agent.getLocalPassword(), agent.getLocalUfrag());
 
         for (LocalCandidate localCandidate : component.getLocalCandidates()) {
@@ -51,6 +57,10 @@ public class CandidateUtil {
 
     public static void unpackCandidates(CandidatesMessage remoteCandidatesMessage, Agent agent, Component component, IceMediaStream mediaStream, boolean allowHost, boolean allowReflexive, boolean allowRelay) {
         Collections.sort(remoteCandidatesMessage.getCandidates());
+
+        if(! allowHost || ! allowReflexive || !allowRelay) {
+            log.info("Peer {}: Disallowing incoming candidates, host: {}, reflexive: {}, relay: {}", remoteCandidatesMessage.getSrcId(), allowHost, allowReflexive, allowRelay);
+        }
 
         //Set candidates
         mediaStream.setRemotePassword(remoteCandidatesMessage.getPassword());

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/EchoLatencyEstimator.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/EchoLatencyEstimator.java
@@ -1,0 +1,97 @@
+package com.faforever.iceadapter.util.latencyestimation;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+
+@Slf4j
+public class EchoLatencyEstimator {
+
+    private static final int LATENCY_ESTIMATION_RETRIES = 3;
+    private static final int LATENCY_ESTIMATION_RETRY_PERIOD = 500;
+
+    private static final double UNREACHABLE_LATENCY = 10000.0;
+
+
+    // estimate latency multiple times and take lowest to compensate for server processing time
+    public static CompletableFuture<Double> getLatency(String hostname) {
+        log.info("Estimating latency to {} using echo server ping", hostname);
+
+        return CompletableFuture.supplyAsync(() -> {
+            List<CompletableFuture<Double>> estimations = new ArrayList<>();
+            for(int i = 0;i < LATENCY_ESTIMATION_RETRIES;i++) {
+                int finalI = i;
+                estimations.add(pingEchoServer(hostname, finalI * LATENCY_ESTIMATION_RETRY_PERIOD));
+            }
+
+            CompletableFuture<Double> all = CompletableFuture.allOf(estimations.toArray(new CompletableFuture[0])).thenApply((ignored) -> {
+                double lowest = estimations.stream().mapToDouble(f1 -> {
+                    try {
+                        return f1.get();
+                    } catch (ExecutionException | InterruptedException | CancellationException e) {
+                        log.error("Error while obtaining latency for echo server {}", hostname, e);
+                        return UNREACHABLE_LATENCY;
+                    }
+                }).min().orElse(UNREACHABLE_LATENCY);
+                return lowest;
+            });
+
+            try {
+                return all.get(3000, TimeUnit.MILLISECONDS);
+            } catch(ExecutionException | InterruptedException | CancellationException | TimeoutException e) {
+                log.warn("Error or timeout while obtaining latency for echo server {}", hostname, e);
+                return UNREACHABLE_LATENCY;
+            }
+        });
+    }
+
+    // connect to the faf server and send a ping command, waiting for the pong response
+    public static CompletableFuture<Double> pingEchoServer(String hostname, int delay) {
+        return CompletableFuture.supplyAsync(() -> {
+            try { Thread.sleep(delay); } catch(InterruptedException ignored) {}
+
+            try (Socket socket = new Socket()) {
+                socket.setSoTimeout(1000);
+                socket.connect(new InetSocketAddress(InetAddress.getByName(hostname), 14010), 1000);
+
+                DataInputStream in = new DataInputStream(socket.getInputStream());
+                DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+                byte[] data = new byte[100];
+                Arrays.fill(data, (byte) 55);
+
+                long startTime = System.currentTimeMillis();
+                out.write(data, 0, 100);
+                out.flush();
+
+                // returns '{"command":"pong"}'
+                byte[] buffer = new byte[10];
+                int bytesReceived = 0;
+                while(bytesReceived < 4) {
+                    bytesReceived += in.read(buffer, bytesReceived, buffer.length - bytesReceived);
+                }
+
+                long latency = System.currentTimeMillis() - startTime;
+
+                in.close();
+                out.close();
+                socket.close();
+
+                return (double) latency;
+            } catch(IOException | RuntimeException e) {
+                log.error("Error while estimating latency to {} using echo server", hostname, e);
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+}

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/FafLatencyEstimator.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/FafLatencyEstimator.java
@@ -1,0 +1,94 @@
+package com.faforever.iceadapter.util.latencyestimation;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+@Slf4j
+public class FafLatencyEstimator {
+
+    private static final int FAF_LATENCY_ESTIMATION_RETRIES = 3;
+    private static final int FAF_LATENCY_ESTIMATION_RETRY_PERIOD = 500;
+    public static final String FAF_REQUEST = "{\"command\":\"ping\"}\n";
+
+    private static final double UNREACHABLE_LATENCY = 10000.0;
+
+
+    // estimate latency multiple times and take lowest to compensate for server processing time
+    public static CompletableFuture<Double> getLatency(String hostname) {
+        log.info("Estimating latency to {} using faf lobby server ping", hostname);
+
+        return CompletableFuture.supplyAsync(() -> {
+            List<CompletableFuture<Double>> estimations = new ArrayList<>();
+            for(int i = 0;i < FAF_LATENCY_ESTIMATION_RETRIES;i++) {
+                int finalI = i;
+                estimations.add(pingFafServer(hostname, finalI * FAF_LATENCY_ESTIMATION_RETRY_PERIOD));
+            }
+
+            CompletableFuture<Double> all = CompletableFuture.allOf(estimations.toArray(new CompletableFuture[0])).thenApply((ignored) -> {
+                double lowest = estimations.stream().mapToDouble(f1 -> {
+                    try {
+                        return f1.get();
+                    } catch (ExecutionException | InterruptedException | CancellationException e) {
+                        log.error("Error while obtaining latency for faf server {}", hostname, e);
+                        return UNREACHABLE_LATENCY;
+                    }
+                }).min().orElse(UNREACHABLE_LATENCY);
+                return lowest;
+            });
+
+            try {
+                return all.get(3000, TimeUnit.MILLISECONDS);
+            } catch(ExecutionException | InterruptedException | CancellationException | TimeoutException e) {
+                log.warn("Error or timeout while obtaining latency for faf server {}", hostname, e);
+                return UNREACHABLE_LATENCY;
+            }
+        });
+    }
+
+    // connect to the faf server and send a ping command, waiting for the pong response
+    public static CompletableFuture<Double> pingFafServer(String hostname, int delay) {
+        return CompletableFuture.supplyAsync(() -> {
+            try { Thread.sleep(delay); } catch(InterruptedException ignored) {}
+
+            try (Socket socket = new Socket()) {
+                socket.setSoTimeout(1000);
+                socket.connect(new InetSocketAddress(InetAddress.getByName(hostname), 8002), 1000);
+
+                DataInputStream in = new DataInputStream(socket.getInputStream());
+                DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+                long startTime = System.currentTimeMillis();
+                out.write(FAF_REQUEST.getBytes(StandardCharsets.UTF_8));
+                out.flush();
+
+                // returns '{"command":"pong"}'
+                byte[] buffer = new byte[65536];
+                int bytesReceived = 0;
+                while(bytesReceived < 4) {
+                    bytesReceived += in.read(buffer, bytesReceived, buffer.length - bytesReceived);
+                }
+
+                long latency = System.currentTimeMillis() - startTime;
+
+                in.close();
+                out.close();
+                socket.close();
+
+                return (double) latency;
+            } catch(IOException | RuntimeException e) {
+                log.error("Error while estimating latency to {} using faf lobby server ping", hostname, e);
+                throw new CompletionException(e);
+            }
+        });
+    }
+}

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/HttpLatencyEstimator.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/HttpLatencyEstimator.java
@@ -1,0 +1,86 @@
+package com.faforever.iceadapter.util.latencyestimation;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+@Slf4j
+public class HttpLatencyEstimator {
+
+//    public static final String HTTP_REQUEST = "GET / HTTP/1.1\n" +
+//            "Host: traefik.%s\n" +
+//            "\n";
+    public static final String HTTP_REQUEST = "GET / HTTP/0.0\n\n";
+
+    public static CompletableFuture<Double> getLatencyManualHttp(String hostname) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Socket socket = new Socket()) {
+                log.info("Estimating latency to {} using http", hostname);
+
+                socket.connect(new InetSocketAddress(InetAddress.getByName(hostname), 80));
+                DataInputStream in = new DataInputStream(socket.getInputStream());
+                DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+                long startTime = System.currentTimeMillis();
+                out.write(String.format(HTTP_REQUEST, hostname).getBytes(StandardCharsets.UTF_8));
+                out.flush();
+
+                byte[] buffer = new byte[65536];
+                int bytesReceived = 0;
+                while(bytesReceived < 4) {
+                    bytesReceived += in.read(buffer, bytesReceived, buffer.length - bytesReceived);
+                } // TODO timeout
+
+                System.out.println("Received " + new String(Arrays.copyOfRange(buffer, 0, bytesReceived)));
+
+                long latency = System.currentTimeMillis() - startTime;
+
+                in.close();
+                out.close();
+                socket.close();
+
+                return (double) latency;
+            } catch(IOException | RuntimeException e) {
+                log.error("Error while estimating latency to {} using http", hostname);
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+
+
+    public static CompletableFuture<Double> getLatencyHttp(String hostname) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                log.info("Estimating latency to {} using http", hostname);
+
+
+                HttpURLConnection connection = (HttpURLConnection) (new URL(String.format("https://traefik.%s", hostname))).openConnection();
+                connection.setRequestMethod("GET");
+                connection.setUseCaches(false);
+
+                long startTime = System.currentTimeMillis();
+                connection.connect();
+
+                if(connection.getResponseCode() != 401) {
+                    log.error("Received response code {} while attempting to estimate latency to {}", connection.getResponseCode(), hostname);
+                    throw new RuntimeException("Invalid http response code " + connection.getResponseCode());
+                }
+
+                long latency = System.currentTimeMillis() - startTime;
+
+                return (double) latency;
+            } catch(IOException | RuntimeException e) {
+                log.error("Error while estimating latency to {} using http", hostname);
+                throw new CompletionException(e);
+            }
+        });
+    }
+}

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/LatencyEstimator.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/LatencyEstimator.java
@@ -1,0 +1,26 @@
+package com.faforever.iceadapter.util.latencyestimation;
+
+import com.faforever.iceadapter.IceAdapter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class LatencyEstimator {
+
+    private static final List<String> FAF_ESTIMATION_HOSTNAMES = Collections.emptyList();
+    private static final List<String> ECHO_ESTIMATION_HOSTNAMES = Collections.singletonList("faforever.com");
+
+    public static CompletableFuture<Double> getLatency(String hostname) {
+        if(ECHO_ESTIMATION_HOSTNAMES.contains(hostname)) {
+            System.err.println("Using geosearchef.de for echo latency estimation instead!!!!");
+            hostname = "geosearchef.de"; // TODO: REMOVE AFTER DEPLOYMENT; FOR TESTING PURPOSES ONLY
+            return EchoLatencyEstimator.getLatency(hostname);
+        } else if(FAF_ESTIMATION_HOSTNAMES.contains(hostname)) {
+            return FafLatencyEstimator.getLatency(hostname);
+        } else {
+            return PingWrapper.getLatency(hostname, IceAdapter.PING_COUNT);
+        }
+    }
+
+}

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/PingWrapper.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/latencyestimation/PingWrapper.java
@@ -1,4 +1,4 @@
-package com.faforever.iceadapter.util;
+package com.faforever.iceadapter.util.latencyestimation;
 
 import com.google.common.io.CharStreams;
 import lombok.extern.slf4j.Slf4j;

--- a/ice-adapter/src/test/java/LatencyEstimatorTest.java
+++ b/ice-adapter/src/test/java/LatencyEstimatorTest.java
@@ -1,0 +1,14 @@
+import com.faforever.iceadapter.util.latencyestimation.LatencyEstimator;
+
+import java.util.concurrent.ExecutionException;
+
+public class LatencyEstimatorTest {
+
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        double latency = LatencyEstimator.getLatency("faforever.com")
+                .exceptionally(e -> 10000.0)
+                .get();
+
+        System.out.println("Latency to host is " + latency);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'ice-adapter'
 include 'client'
 include 'server'
 include 'shared'
+include 'echo-server'
 


### PR DESCRIPTION
As faforever.com doesn't respond to icmp echo, other methods for latency estimation are required. Most other protocols involve a processing delay by the server included in the roundtrip (http or stun) and are thereby unsuited for latency estimation. Another method would be just opening a tcp connection and measuring the time it takes for the TCP handshake. This is may yield multiple roundtrips though, therefore being unreliable and also causes a server to experience a connection attempt aborted mid way.

Instead, this estimation method uses the FAF lobby server protocol to connect to the server like a client and sends the ping command, timing the response time of the pong command. This is done 3 times at 2 Hz and seems to yield a very reliable estimate.

This should improve connectivity for oceanian players significantly.


Also includes some logging changes and a retry when failing to bind the GPGNet server socket