### PR TITLE
Add release edition without JavaFX on the classpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           ./gradlew -Pversion="${{ github.event.inputs.version }}" -PjavafxPlatform=linux --stacktrace :ice-adapter:shadowJar
 
+      - name: Build No-JavaFX Files
+        run: |
+          ./gradlew -Pversion="${{ github.event.inputs.version }}" -PjavafxPlatform=linux -PjavafxClasspath=compileOnly --stacktrace :ice-adapter:shadowJar
+
       - name: Create Draft Release
         id: create_release
         uses: actions/create-release@v1
@@ -51,10 +55,25 @@ jobs:
           LINUX_JAR_NAME=$(basename $LINUX_JAR)
           WINDOWS_JAR=$(ls ice-adapter/build/libs/faf-ice-adapter-*-win.jar | head -n 1)
           WINDOWS_JAR_NAME=$(basename $WINDOWS_JAR)
+          NOJFX_JAR=$(ls ice-adapter/build/libs/faf-ice-adapter-*-nojfx.jar | head -n 1)
+          NOJFX_JAR_NAME=$(basename $NOJFX_JAR)
           echo ::set-output name=LINUX_JAR::${LINUX_JAR}
           echo ::set-output name=LINUX_JAR_NAME::${LINUX_JAR_NAME}
           echo ::set-output name=WINDOWS_JAR::${WINDOWS_JAR}
           echo ::set-output name=WINDOWS_JAR_NAME::${WINDOWS_JAR_NAME}
+          echo ::set-output name=NOJFX_JAR::${NOJFX_JAR}
+          echo ::set-output name=NOJFX_JAR_NAME::${NOJFX_JAR_NAME}
+
+      - name: Upload NoJFX Files
+        id: upload-nojfx
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.artifact_paths.outputs.NOJFX_JAR }}
+          asset_name: ${{ steps.artifact_paths.outputs.NOJFX_JAR_NAME }}
+          asset_content_type: application/java-archive
 
       - name: Upload Linux Files
         id: upload-linux

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 version=snapshot
 javafxVersion=18.0.2
 javafxPlatform=linux
+javafxClasspath=included
 lombokVersion=1.18.24
 picocliVersion=4.6.3
 gsonVersion=2.9.1

--- a/ice-adapter/build.gradle
+++ b/ice-adapter/build.gradle
@@ -40,16 +40,30 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("ch.qos.logback:logback-core:$logbackVersion")
 
-    implementation("org.openjfx:javafx-base:${javafxVersion}:${javafxPlatform}")
-    implementation("org.openjfx:javafx-controls:${javafxVersion}:${javafxPlatform}")
-    implementation("org.openjfx:javafx-graphics:${javafxVersion}:${javafxPlatform}")
-    implementation("org.openjfx:javafx-fxml:${javafxVersion}:${javafxPlatform}")
-    implementation("org.openjfx:javafx-web:${javafxVersion}:${javafxPlatform}")
-    implementation("org.openjfx:javafx-media:${javafxVersion}:${javafxPlatform}")
+    if(javafxClasspath == "compileOnly") {
+        compileOnly("org.openjfx:javafx-base:${javafxVersion}:${javafxPlatform}")
+        compileOnly("org.openjfx:javafx-controls:${javafxVersion}:${javafxPlatform}")
+        compileOnly("org.openjfx:javafx-graphics:${javafxVersion}:${javafxPlatform}")
+        compileOnly("org.openjfx:javafx-fxml:${javafxVersion}:${javafxPlatform}")
+        compileOnly("org.openjfx:javafx-web:${javafxVersion}:${javafxPlatform}")
+        compileOnly("org.openjfx:javafx-media:${javafxVersion}:${javafxPlatform}")
+    } else {
+        implementation("org.openjfx:javafx-base:${javafxVersion}:${javafxPlatform}")
+        implementation("org.openjfx:javafx-controls:${javafxVersion}:${javafxPlatform}")
+        implementation("org.openjfx:javafx-graphics:${javafxVersion}:${javafxPlatform}")
+        implementation("org.openjfx:javafx-fxml:${javafxVersion}:${javafxPlatform}")
+        implementation("org.openjfx:javafx-web:${javafxVersion}:${javafxPlatform}")
+        implementation("org.openjfx:javafx-media:${javafxVersion}:${javafxPlatform}")
+    }
 }
 
 shadowJar {
-    getArchiveFileName().set("faf-ice-adapter-${version}-${javafxPlatform}.jar")
+    def plattformSuffix = javafxPlatform
+    if(javafxClasspath == "compileOnly") {
+        plattformSuffix = "nojfx"
+    }
+
+    getArchiveFileName().set("faf-ice-adapter-${version}-${plattformSuffix}.jar")
     manifest {
         attributes 'Main-Class': 'com.faforever.iceadapter.IceAdapter'
     }


### PR DESCRIPTION
The Java FAF client brings JavaFX along and doesn't need to include these huge libraries twice.