### PR TITLE
Free the ice4j agent before recreating a new one

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -91,6 +91,10 @@ public class PeerIceModule {
      * Creates an agent and media stream for handling the ICE
      */
     private void createAgent() {
+        if(agent != null) {
+            agent.free();
+        }
+
         agent = new Agent();
         agent.setControlling(peer.isLocalOffer());
 


### PR DESCRIPTION
Since the old agent might not be shutdown and garbage collected immediately, there might be some Stun-related resource blocked.