### PR TITLE
Do not give up on HOST_CANDIDATE / SERVER_REFLEXIVE_CANDIDATE

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -144,8 +144,8 @@ public class PeerIceModule {
         }
 
 
-        int previousConnectivityAttempts = getConnectivityAttempsInThePast(FORCE_SRFLX_RELAY_INTERVAL);
-        CandidatesMessage localCandidatesMessage = CandidateUtil.packCandidates(IceAdapter.id, peer.getRemoteId(), agent, component, previousConnectivityAttempts < FORCE_SRFLX_COUNT && IceAdapter.ALLOW_HOST, previousConnectivityAttempts < FORCE_RELAY_COUNT && IceAdapter.ALLOW_REFLEXIVE, IceAdapter.ALLOW_RELAY);
+        //int previousConnectivityAttempts = getConnectivityAttempsInThePast(FORCE_SRFLX_RELAY_INTERVAL);
+        CandidatesMessage localCandidatesMessage = CandidateUtil.packCandidates(IceAdapter.id, peer.getRemoteId(), agent, component, IceAdapter.ALLOW_HOST, IceAdapter.ALLOW_REFLEXIVE, IceAdapter.ALLOW_RELAY);
         log.debug(getLogPrefix() + "Sending own candidates to {}, offered candidates: {}", peer.getRemoteId(), localCandidatesMessage.candidates().stream().map(it -> it.type().toString() + "(" + it.protocol() + ")").collect(Collectors.joining(", ")));
         setState(AWAITING_CANDIDATES);
         RPCService.onIceMsg(localCandidatesMessage);
@@ -215,8 +215,8 @@ public class PeerIceModule {
 
             setState(CHECKING);
 
-            int previousConnectivityAttempts = getConnectivityAttempsInThePast(FORCE_SRFLX_RELAY_INTERVAL);
-            CandidateUtil.unpackCandidates(remoteCandidatesMessage, agent, component, mediaStream, previousConnectivityAttempts < FORCE_SRFLX_COUNT && IceAdapter.ALLOW_HOST, previousConnectivityAttempts < FORCE_RELAY_COUNT && IceAdapter.ALLOW_REFLEXIVE, IceAdapter.ALLOW_RELAY);
+            //int previousConnectivityAttempts = getConnectivityAttempsInThePast(FORCE_SRFLX_RELAY_INTERVAL);
+            CandidateUtil.unpackCandidates(remoteCandidatesMessage, agent, component, mediaStream, IceAdapter.ALLOW_HOST, IceAdapter.ALLOW_REFLEXIVE, IceAdapter.ALLOW_RELAY);
 
             startIce();
 


### PR DESCRIPTION
Seems like it gives up HOST_CANDIDATE after one failed connection attempt and then don't try that again until 2 minutes have passed
(same with SERVER_REFLEXIVE_CANDIDATE after 2 attempts)

I wonder why that logic is needed, shouldn't ice4j have the chance to try all methods at the time of reconnection, regardless of earlier attempts? For instance when someone temporarily lost their internet access but got it back.