### PR TITLE
Fix possible null dereferencing

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java
@@ -238,8 +238,8 @@ public class GPGNetServer {
      */
     public static void close() {
         if (currentClient != null) {
-            currentClient = null;
             currentClient.close();
+            currentClient = null;
             clientFuture = new CompletableFuture<>();
         }
 


### PR DESCRIPTION
Even if
this has to be set to null:
`currentClient = null;`

I guess most probably not before a call is made to a member function on it.