### PR TITLE
Partial shutdown of virtual threads for Ice4j.

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -370,7 +370,8 @@ public class PeerIceModule {
             connectivityChecker.start();
         }
 
-        listenerThread = Thread.startVirtualThread(this::listener);
+        listenerThread = new Thread(this::listener);
+        listenerThread.start();
     }
 
     /**

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/util/ExecutorHolder.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/util/ExecutorHolder.java
@@ -7,6 +7,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class ExecutorHolder {
     public ExecutorService getExecutor() {
-        return Executors.newVirtualThreadPerTaskExecutor();
+        int numberOfCores = Runtime.getRuntime().availableProcessors();
+        return Executors.newFixedThreadPool(numberOfCores);
     }
 }


### PR DESCRIPTION
Ice4j consists of 70% "synchronized" blocks. This blocks the operation of all virtual threads. 
Now I propose to temporarily return the usual Threads.
Then when 24 jdk is released, return the virtual threads again.

24 JDK  "[JEP 491: Synchronize Virtual Threads without Pinning](https://openjdk.org/jeps/491)"