### PR TITLE
Ensure GPGNetServer uses correct gpgnetPort

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java
@@ -69,7 +69,7 @@ public class GPGNetServer implements AutoCloseable {
         }
 
         try {
-            this.serverSocket = new ServerSocket(gpgnetPort);
+            this.serverSocket = new ServerSocket(this.gpgnetPort);
         } catch (IOException e) {
             log.error("Couldn't start GPGNetServer", e);
             IceAdapter.close(-1);


### PR DESCRIPTION
Since version 3.3.11 (specifically since #67), starting the ICE adapter without the `--gpgnet-port` argument no longer works, as the server is created on the default port (0) rather than on generated one