### PR TITLE
Add `--lobby-init-mode` argument

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/IceAdapter.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/IceAdapter.java
@@ -63,7 +63,7 @@ public class IceAdapter implements Callable<Integer>, AutoCloseable, FafRpcCallb
         PeerIceModule.setForceRelay(iceOptions.isForceRelay());
         gpgNetServer = new GPGNetServer();
         rpcService = new RPCService();
-        gpgNetServer.init(iceOptions.getGpgnetPort(), iceOptions.getLobbyPort(), rpcService);
+        gpgNetServer.init(iceOptions.getGpgnetPort(), iceOptions.getLobbyPort(), rpcService, iceOptions.getLobbyInitMode());
         rpcService.init(iceOptions.getRpcPort(), gpgNetServer, this);
 
         PeerIceModule.setForceRelay(iceOptions.isForceRelay());

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/IceOptions.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/IceOptions.java
@@ -62,4 +62,10 @@ public class IceOptions {
             defaultValue = "wss://ice-telemetry.faforever.com",
             description = "Telemetry server to connect to")
     private String telemetryServer;
+
+    @Option(
+            names = "--lobby-init-mode",
+            defaultValue = "normal",
+            description = "lobby mode the game will use. Supported values are 'normal' for normal lobby and 'auto' for automatch lobby (aka ladder).")
+    private String lobbyInitMode;
 }

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/gpgnet/GPGNetServer.java
@@ -48,9 +48,10 @@ public class GPGNetServer implements AutoCloseable {
         return INSTANCE.lobbyInitMode;
     }
 
-    public void init(int gpgnetPort, int lobbyPort, RPCService rpcService) {
+    public void init(int gpgnetPort, int lobbyPort, RPCService rpcService, String lobbyInitMode) {
         INSTANCE = this;
         this.rpcService = rpcService;
+        this.lobbyInitMode = LobbyInitMode.getByName(lobbyInitMode);
 
         if (gpgnetPort == 0) {
             this.gpgnetPort = NetworkToolbox.findFreeTCPPort(20000, 65536);


### PR DESCRIPTION
The faf-client already knows the lobby init mode before launching the game and ICE adapter, so we can pass it as a command line argument