### PR TITLE
Validate echo length; use virtual thread for ICE listener

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerConnectivityCheckerModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerConnectivityCheckerModule.java
@@ -92,6 +92,7 @@ public class PeerConnectivityCheckerModule {
         if (length != 9) {
             log.trace("Received echo of wrong length, length: {}", length);
             invalidEchosReceived++;
+            return;
         }
 
         int rtt =

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -382,8 +382,8 @@ public class PeerIceModule {
             connectivityChecker.start();
         }
 
-        listenerThread = new Thread(this::listener);
-        listenerThread.start();
+        listenerThread =
+                Thread.ofVirtual().name("ice-listener-" + peer.getRemoteId()).start(this::listener);
     }
 
     /**


### PR DESCRIPTION
## Two small unrelated cleanups around the ICE peer listener

### 1. `PeerConnectivityCheckerModule.echoReceived()` — early return on bad length

When an echo packet's `length != 9`, the code increments `invalidEchosReceived` and logs a trace, but then falls through to:

```java
int rtt = (int) (System.currentTimeMillis()
        - Longs.fromByteArray(Arrays.copyOfRange(data, offset + 1, length)));
```

- If `length < 9` → `Longs.fromByteArray` throws `IllegalArgumentException` (it requires exactly 8 bytes).
- If `length > 9` → the first 8 bytes after the type prefix are reinterpreted as a timestamp, the resulting bogus RTT poisons the EMA at line 102, and subsequent `averageRTT` reporting becomes corrupted.

Adds an early `return` so invalid echoes only update the counter and don't compute an RTT.

### 2. `PeerIceModule.startIce()` — virtual thread for the data listener

PR #65 migrated this project to virtual threads (the connectivity checker, the telemetry sending loop, and the GPGNet/RPC acceptors are all `Thread.ofVirtual()`). The data listener inside `PeerIceModule` was missed — it still uses `new Thread(this::listener)`, which means every peer holds a carrier thread blocked on `socket.receive()` for no benefit.

Replaces with `Thread.ofVirtual().name("ice-listener-" + peer.getRemoteId()).start(this::listener)` to match the surrounding code.

## Risk

Both changes are local and self-contained. No behavior change other than the bug fix in (1). The listener thread continues to be assigned to the same `volatile Thread listenerThread` field and gets interrupted/joined exactly the same way on close.

## Verification

Local Spotless + check pass on the fix branch. No JUnit tests added in this PR — happy to follow up with one for the echo-length validation if maintainers want it (would land alongside the JUnit infrastructure I proposed in the cover note of #84).

---
*Co-authored with Claude (Anthropic); reviewed and locally verified by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced peer connectivity validation to properly detect and reject malformed echo responses, preventing corruption of round-trip time measurements and improving connection reliability.

* **Performance**
  * Optimized internal threading for peer connectivity management to reduce resource overhead and improve efficiency during connection establishment and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->