### PR TITLE
Cap reconnect attempts in PeerIceModule (default 5)

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -54,6 +54,7 @@ public class PeerIceModule {
             2 * 60 * 1000; // 2 mins, the interval in which multiple connects have to happen to force srflx/relay
     private static final int FORCE_SRFLX_COUNT = 1;
     private static final int FORCE_RELAY_COUNT = 2;
+    private static final int MAX_RECONNECT_ATTEMPTS = 5;
 
     private final Peer peer;
 
@@ -74,6 +75,8 @@ public class PeerIceModule {
     private final List<Long> connectivityAttemptTimes = new ArrayList<>();
     // How often have we been waiting for a response to local candidates/offer
     private final AtomicInteger awaitingCandidatesEventId = new AtomicInteger(0);
+    // Counts consecutive reconnect attempts since the last successful CONNECTED state; used to cap the retry loop
+    private final AtomicInteger consecutiveFailedAttempts = new AtomicInteger(0);
 
     private final Lock lockInit = new ReentrantLock();
     private final Lock lockLostConnection = new ReentrantLock();
@@ -370,6 +373,7 @@ public class PeerIceModule {
 
         // We are connected
         connected = true;
+        consecutiveFailedAttempts.set(0);
         rpcService.onConnected(IceAdapter.getId(), peer.getRemoteId(), true);
         setState(CONNECTED);
 
@@ -440,19 +444,23 @@ public class PeerIceModule {
             }
 
             if (previousState == CONNECTED) {
+                consecutiveFailedAttempts.set(0);
                 TrayIcon.showMessage("Reconnecting to %s (connection lost)".formatted(this.peer.getRemoteLogin()));
             }
 
-            if (previousState == CONNECTED && peer.isLocalOffer()) {
-                // We were connected before, retry immediately
+            if (peer.isLocalOffer()) {
+                int attempt = consecutiveFailedAttempts.incrementAndGet();
+                if (attempt > MAX_RECONNECT_ATTEMPTS) {
+                    log.warn(
+                            "{} Giving up after {} consecutive failed reconnect attempts. Use the FAF client's reconnect button to try again.",
+                            getLogPrefix(),
+                            MAX_RECONNECT_ATTEMPTS);
+                    return;
+                }
+                long delayMs = (previousState == CONNECTED) ? 0 : 5000;
                 CompletableFuture.runAsync(
                         this::initiateIce,
-                        CompletableFuture.delayedExecutor(0, TimeUnit.MILLISECONDS, IceAdapter.getExecutor()));
-            } else if (peer.isLocalOffer()) {
-                // Last ice attempt didn't succeed, so wait a bit
-                CompletableFuture.runAsync(
-                        this::initiateIce,
-                        CompletableFuture.delayedExecutor(5000, TimeUnit.MILLISECONDS, IceAdapter.getExecutor()));
+                        CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS, IceAdapter.getExecutor()));
             }
         });
     }


### PR DESCRIPTION
## Problem

`PeerIceModule.onConnectionLost()` schedules a new `initiateIce()` on every failure with **no upper bound on attempts**. When a peer truly disappears mid-game — their machine crashes, FA closes, or a P2P route in the mesh breaks in a way that won't recover — the retry loop runs until local FA shutdown:

- every ~11 seconds: gather STUN + TURN candidates, send them via RPC to the lobby server, wait 6 s for the peer's response, fail, schedule another attempt
- in a 16-player game with one bad link, this is one P2P session burning CPU/network/log indefinitely while the simulation has long since moved past

## Real-world evidence

A deadlocked 16-player session: a single peer drop produced **112 ICE re-initiations across 20 minutes** for one peer that never returned. The local FA's lockstep took ~10 s to mark the peer defeated and continue (per game-engine state in `JsonStats`), but the ice-adapter spent the next ~20 minutes retrying into the void:

- 100+ state-change notifications (`onIceConnectionStateChanged: gathering / awaitingCandidates / disconnected`) sent to the FAF client
- Continuous STUN/TURN harvesting (5 servers per attempt × 112 attempts = ~560 round trips)
- Telemetry websocket churn coupled to each state change

A separate teammate's log from a different session shows a peer **flapping** with 3 successful reconnects in 26 seconds — those recoveries happen well within a 5-attempt budget, so this cap does not regress the transient-flap recovery case that the existing retry loop is designed to handle.

## Change

Adds a counter for consecutive failed reconnect attempts:

- **Reset to 0 in `startIce()`** when `CONNECTED` is reached. A successful connection clears the budget.
- **Reset to 0 in `onConnectionLost()`** when the previous state was `CONNECTED` (a fresh disconnect deserves a fresh retry budget).
- **Incremented on every retry attempt.**
- Once `attempt > MAX_RECONNECT_ATTEMPTS` (default 5), `onConnectionLost()` returns without scheduling a new `initiateIce()`. State stays `DISCONNECTED`.

Total automatic-retry budget: about 55 seconds (5 attempts × ~11 s each).

## Recovery semantics (unchanged)

- The FAF client's **manual reconnect button** (`#61`) calls `GameSession.reconnectToPeer()`, which `disconnect`s and re-`connectToPeer()`s. That creates a fresh `Peer` and a fresh `PeerIceModule` — counter starts at 0 again. Users retain explicit control to retry.
- **Answerer-mode peers** continue to react to new offers received via `onIceMessageReceived()` regardless of cap state — that path goes through `initiateIce()` directly, not the retry scheduler.

## Risk

- The `MAX_RECONNECT_ATTEMPTS = 5` constant is conservative. Could be made configurable via `IceOptions` in a follow-up if maintainers want tournament-mode tuning. Kept hardcoded here for minimal scope.
- Behavior is unchanged for any peer that successfully reconnects within 5 attempts (which is every recovering peer in the available real-world logs).
- Behavior changes for peers that never recover: the adapter now stops retrying after ~55 s instead of looping forever.

## Verification

- Local `:ice-adapter:check` (compile + spotlessCheck) passes after `spotlessApply`.
- No JUnit tests added — `ice-adapter` has no JUnit infrastructure yet, and bringing it in alongside this change would expand scope. Happy to follow up with a regression test (and the JUnit infrastructure for it) if maintainers want.

---
*Co-authored with Claude (Anthropic); reviewed and locally verified by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Implemented a limit of 5 consecutive reconnection attempts to prevent infinite connection loops and improve system stability.
* Enhanced connection recovery with intelligent retry delays and improved connection state tracking for better resilience during network disruptions.
* Added notifications to inform users when maximum reconnection attempts are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->