### PR TITLE
Make echo interval and timeout configurable

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/IceAdapter.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/IceAdapter.java
@@ -194,6 +194,14 @@ public class IceAdapter implements Callable<Integer>, AutoCloseable, FafRpcCallb
         return INSTANCE.iceOptions.getAcceptableLatency();
     }
 
+    public static int getEchoIntervalMs() {
+        return INSTANCE.iceOptions.getEchoIntervalMs();
+    }
+
+    public static int getEchoTimeoutMs() {
+        return INSTANCE.iceOptions.getEchoTimeoutMs();
+    }
+
     public static Executor getExecutor() {
         return INSTANCE.executor;
     }

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/IceOptions.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/IceOptions.java
@@ -62,4 +62,17 @@ public class IceOptions {
             defaultValue = "wss://ice-telemetry.faforever.com",
             description = "Telemetry server to connect to")
     private String telemetryServer;
+
+    @Option(
+            names = "--echo-interval-ms",
+            defaultValue = "1000",
+            description = "interval (ms) at which connectivity-check echo packets are sent to peers")
+    private int echoIntervalMs;
+
+    @Option(
+            names = "--echo-timeout-ms",
+            defaultValue = "10000",
+            description =
+                    "silence threshold (ms) before a peer is declared disconnected; lower values speed up peer-loss detection")
+    private int echoTimeoutMs;
 }

--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerConnectivityCheckerModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerConnectivityCheckerModule.java
@@ -19,8 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PeerConnectivityCheckerModule {
 
-    private static final int ECHO_INTERVAL = 1000;
-
     private final PeerIceModule ice;
     private final Lock lockIce = new ReentrantLock();
     private volatile boolean running = false;
@@ -125,7 +123,7 @@ public class PeerConnectivityCheckerModule {
             debug().peerConnectivityUpdate(peer);
 
             try {
-                Thread.sleep(ECHO_INTERVAL);
+                Thread.sleep(IceAdapter.getEchoIntervalMs());
             } catch (InterruptedException e) {
                 log.warn(
                         "{} (sleeping checkerThread) was interrupted",
@@ -133,9 +131,11 @@ public class PeerConnectivityCheckerModule {
                 return;
             }
 
-            if (System.currentTimeMillis() - lastPacketReceived > 10000) {
+            int timeoutMs = IceAdapter.getEchoTimeoutMs();
+            if (System.currentTimeMillis() - lastPacketReceived > timeoutMs) {
                 log.warn(
-                        "Didn't receive any answer to echo requests for the past 10 seconds from {}, aborting connection",
+                        "Didn't receive any answer to echo requests for the past {}ms from {}, aborting connection",
+                        timeoutMs,
                         peer.getRemoteLogin());
                 CompletableFuture.runAsync(ice::onConnectionLost, IceAdapter.getExecutor());
                 return;


### PR DESCRIPTION
## Problem

`PeerConnectivityCheckerModule` is the only thing standing between "this peer is healthy" and "this peer is dead." Both knobs are hardcoded:

```java
private static final int ECHO_INTERVAL = 1000;        // checkerThread, line 22
...
if (System.currentTimeMillis() - lastPacketReceived > 10000) {   // line 136
```

The 10-second silence threshold puts a hard floor on the user-visible deadlock window when a peer drops mid-game: SC's lockstep simulation stalls until the adapter declares the peer disconnected, and that takes 10 seconds regardless of how fast the actual drop was. Tournament players (and anyone debugging chronic mesh drops) have no way to tighten this.

## Real-world evidence

A 16-player game session: one peer experienced what looked like a JVM/CPU pause on their machine. From the local adapter's perspective the peer simply went silent. The game froze for every other player while the lockstep waited for input that wasn't coming, until the 10-second echo timeout fired and the simulation could move on with a vote-to-continue. The full freeze duration is essentially `ECHO_TIMEOUT_MS + (FA's vote-grace period)`.

A separate teammate's log shows a flapping peer with three echo timeouts inside 26 seconds, each followed by a successful re-establishment. With the same data and a 2-second timeout, those would have been 2-second blips instead of 10-second freezes.

## Change

Two new CLI options, defaults preserve current behavior:

| Option | Default | Effect |
|---|---|---|
| `--echo-interval-ms` | `1000` | Cadence at which the connectivity checker sends echo packets to peers. |
| `--echo-timeout-ms` | `10000` | Silence threshold before declaring a peer disconnected. |

Files touched:

- `IceOptions.java` — adds the two `@Option` fields.
- `IceAdapter.java` — adds two static accessors (`getEchoIntervalMs()`, `getEchoTimeoutMs()`) following the existing pattern (`getPingCount`, `getAcceptableLatency`).
- `PeerConnectivityCheckerModule.java` — replaces the two hardcoded values with calls to the new accessors. The log message at line 138 becomes `"for the past {}ms from {}"` (was `"for the past 10 seconds from {}"`) so it reflects the configured value, but the prefix `Didn't receive any answer to echo requests` stays identical so existing log-grep tooling continues to work.

## Use cases

- **Tournament play / fast-recovery**: `--echo-timeout-ms 2000 --echo-interval-ms 500`. Detects peer loss in 2 seconds; loses 4 echoes before declaring dead (still robust to occasional packet loss). Combined with the FAF client's existing reconnect logic, this makes brief network blips much less disruptive.
- **Slow / high-latency links**: leave defaults, or even widen `--echo-timeout-ms 15000` if needed.
- **Debugging chronic disconnects**: tighten timeouts during repro to make incidents fail faster and cluster more visibly in logs.

## Risk

- Defaults are unchanged, so any caller (FAF client, manual launchers) that doesn't pass the new options sees identical behavior.
- The log message changes one numeric value and the unit suffix; the grep prefix is preserved.
- No new threads, locks, or state. The two values are read on each iteration of the checker thread, so a hot config swap would even be possible — though that's not exposed here, since the values are CLI-set once at startup.

## Verification

- Local `:ice-adapter:check` (compile + spotlessCheck) passes after `spotlessApply`.
- Manual smoke test by passing `--echo-timeout-ms 2000` and observing the connectivity check now fires after 2 s (verified with the existing repro pattern — silent UDP server).

---
*Co-authored with Claude (Anthropic); reviewed and locally verified by me.*
