### PR TITLE
Update iceState to DISCONNECTED in PeerIceModule.close() (fixes #59)

### DIFF
--- a/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
+++ b/ice-adapter/src/main/java/com/faforever/iceadapter/ice/PeerIceModule.java
@@ -565,11 +565,29 @@ public class PeerIceModule {
         }
         if (turnRefreshModule != null) {
             turnRefreshModule.close();
-        }
-        if (agent != null) {
-            agent.free();
+            turnRefreshModule = null;
         }
         connectivityChecker.stop();
+
+        // Mirror the state notifications that onConnectionLost() sends so the FAF client
+        // and telemetry see this peer as fully disconnected. Without this, iceState stayed
+        // at whatever it was (typically CONNECTED) when the peer was closed via the RPC
+        // disconnect path or game-end teardown - the desync reported in issue #59
+        // ("Socket closed, when state Connected").
+        if (connected) {
+            connected = false;
+            rpcService.onConnected(IceAdapter.getId(), peer.getRemoteId(), false);
+        }
+        if (iceState != DISCONNECTED) {
+            setState(DISCONNECTED);
+        }
+
+        if (agent != null) {
+            agent.free();
+            agent = null;
+            mediaStream = null;
+            component = null;
+        }
     }
 
     public long getConnectivityAttempsInThePast(final long millis) {


### PR DESCRIPTION
## Problem (closes #59)

[Issue #59](https://github.com/FAForever/java-ice-adapter/issues/59) reports a state desync where three things are simultaneously true:

- the game shows no connection to the peer
- the ICE debug window shows the peer's state as `Connected`
- the logs report `SocketException: Socket closed`

The original report includes stack traces from `Peer.java` and `PeerIceModule.java` listener loops that fire after the underlying socket has been closed — but the adapter's `iceState` field is still `CONNECTED`.

## Root cause

`PeerIceModule.close()` does the cleanup work (interrupts the listener thread, closes the TURN refresh module, frees the ice4j `Agent`, stops the connectivity checker) but does not:

- set `connected = false`
- call `rpcService.onConnected(..., false)`
- call `setState(DISCONNECTED)` (which would notify both RPC and the telemetry/debug pipeline)
- null out the `agent`, `mediaStream`, and `component` references after `agent.free()`

So whatever `iceState` was when `close()` ran — typically `CONNECTED` because `close()` is invoked either from the RPC disconnect-from-peer path on a live peer or from `GameSession.close()` during game teardown — stays put. The FAF client never gets a state-change notification matching the actual closed-socket reality, the telemetry server's UI shows the peer as still connected, and any code path reading `peer.getIce().getIceState()` returns `CONNECTED` for a peer whose socket is gone.

The companion method `onConnectionLost()` does this correctly already. `close()` is the outlier.

## Change

Rewrite `PeerIceModule.close()` to mirror `onConnectionLost()`'s cleanup-then-notify-then-free flow:

```diff
     void close() {
         if (listenerThread != null) {
             listenerThread.interrupt();
             listenerThread = null;
         }
         if (turnRefreshModule != null) {
             turnRefreshModule.close();
+            turnRefreshModule = null;
         }
+        connectivityChecker.stop();
+
+        // Mirror the state notifications that onConnectionLost() sends so the FAF client
+        // and telemetry see this peer as fully disconnected. Without this, iceState stayed
+        // at whatever it was (typically CONNECTED) when the peer was closed via the RPC
+        // disconnect path or game-end teardown - the desync reported in issue #59
+        // ("Socket closed, when state Connected").
+        if (connected) {
+            connected = false;
+            rpcService.onConnected(IceAdapter.getId(), peer.getRemoteId(), false);
+        }
+        if (iceState != DISCONNECTED) {
+            setState(DISCONNECTED);
+        }
+
         if (agent != null) {
             agent.free();
+            agent = null;
+            mediaStream = null;
+            component = null;
         }
-        connectivityChecker.stop();
     }
```

The `connected` and `iceState` checks prevent firing duplicate notifications when `close()` runs after `onConnectionLost()` has already updated state (e.g. peer drop followed by game-end cleanup).

## Risk

Low. The new behavior is exactly what `onConnectionLost()` already does for the same fields. The state machine is unchanged for paths that go through `onConnectionLost()`; only the close() path now reports its actual outcome.

## Side benefit

The dangling-reference cleanup (nulling `agent`, `mediaStream`, `component` after `free()`, plus `turnRefreshModule` after its `close()`) matches what `onConnectionLost()` does and reduces the chance the listener thread sees half-freed state during shutdown — partially defusing the known race that the `catch (NullPointerException)` in `PeerIceModule.listener()` exists to defend against.

## Verification

- Local `:ice-adapter:check` (compile + spotlessCheck) passes after `spotlessApply`.
- The change pattern (mirroring `onConnectionLost`'s state notification) is identical to existing well-tested code paths.

Closes #59.

---
*Co-authored with Claude (Anthropic); reviewed and locally verified by me.*
